### PR TITLE
Add In Use and Waiting Connections metrics for DBConnection.ConnectionPool

### DIFF
--- a/lib/db_connection/connection_pool.ex
+++ b/lib/db_connection/connection_pool.ex
@@ -22,6 +22,10 @@ defmodule DBConnection.ConnectionPool do
     GenServer.start_link(__MODULE__, {mod, opts}, start_opts(opts))
   end
 
+  def get_metrics(pid) do
+    GenServer.call(pid, :get_metrics)
+  end
+
   ## GenServer api
 
   def init({mod, opts}) do
@@ -34,14 +38,21 @@ defmodule DBConnection.ConnectionPool do
     codel = %{target: target, interval: interval, delay: 0, slow: false,
               next: now, poll: nil, idle_interval: idle_interval, idle: nil}
     codel = start_idle(now, now, start_poll(now, now, codel))
-    {:ok, {:busy, queue, codel}}
+    {:ok, {:busy, queue, codel, %{
+      active_connections: 0,
+      waiting_connections: 0
+    }}}
   end
 
-  def handle_info({:db_connection, from, {:checkout, _caller, now, queue?}}, {:busy, queue, _} = busy) do
+  def handle_call(:get_metrics, _from, {_, _, _, metrics} = state) do
+    {:reply, metrics, state}
+  end
+
+  def handle_info({:db_connection, from, {:checkout, _caller, now, queue?}}, {:busy, queue, codel, metrics} = busy) do
     case queue? do
       true ->
         :ets.insert(queue, {{now, System.unique_integer(), from}})
-        {:noreply, busy}
+        {:noreply, {:busy, queue, codel, %{metrics | waiting_connections: metrics.waiting_connections + 1}}}
       false ->
         message = "connection not available and queuing is disabled"
         err = DBConnection.ConnectionError.exception(message)
@@ -51,24 +62,24 @@ defmodule DBConnection.ConnectionPool do
   end
 
   def handle_info({:db_connection, from, {:checkout, _caller, _now, _queue?}} = checkout, ready) do
-    {:ready, queue, _codel} = ready
+    {:ready, queue, _codel, metrics} = ready
     case :ets.first(queue) do
       {_time, holder} = key ->
         Holder.handle_checkout(holder, from, queue) and :ets.delete(queue, key)
-        {:noreply, ready}
+        {:noreply, {:ready, queue, _codel, %{metrics | active_connections: metrics.active_connections + 1}}}
       :"$end_of_table" ->
         handle_info(checkout, put_elem(ready, 0, :busy))
     end
   end
 
-  def handle_info({:"ETS-TRANSFER", holder, pid, queue}, {_, queue, _} = data) do
+  def handle_info({:"ETS-TRANSFER", holder, pid, queue}, {_, queue, _, _metrics} = data) do
     message = "client #{inspect pid} exited"
     err = DBConnection.ConnectionError.exception(message)
     Holder.handle_disconnect(holder, err)
     {:noreply, data}
   end
 
-  def handle_info({:"ETS-TRANSFER", holder, _, {msg, queue, extra}}, {_, queue, _} = data) do
+  def handle_info({:"ETS-TRANSFER", holder, _, {msg, queue, extra}}, {_, queue, _, _metrics} = data) do
     case msg do
       :checkin ->
         owner = self()
@@ -87,7 +98,7 @@ defmodule DBConnection.ConnectionPool do
     end
   end
 
-  def handle_info({:timeout, deadline, {queue, holder, pid, len}}, {_, queue, _} = data) do
+  def handle_info({:timeout, deadline, {queue, holder, pid, len}}, {_, queue, _, _metrics} = data) do
     # Check that timeout refers to current holder (and not previous)
     if Holder.handle_deadline(holder, deadline) do
       message = "client #{inspect pid} timed out because " <>
@@ -98,22 +109,22 @@ defmodule DBConnection.ConnectionPool do
     {:noreply, data}
   end
 
-  def handle_info({:timeout, poll, {time, last_sent}}, {_, _, %{poll: poll}} = data) do
-    {status, queue, codel} = data
+  def handle_info({:timeout, poll, {time, last_sent}}, {_, _, %{poll: poll}, metrics} = data) do
+    {status, queue, codel, metrics} = data
 
     # If no queue progress since last poll check queue
     case :ets.first(queue) do
       {sent, _, _} when sent <= last_sent and status == :busy ->
         delay = time - sent
-        timeout(delay, time, queue, start_poll(time, sent, codel))
+        timeout(delay, time, queue, start_poll(time, sent, codel), metrics)
       {sent, _, _} ->
-        {:noreply, {status, queue, start_poll(time, sent, codel)}}
+        {:noreply, {status, queue, start_poll(time, sent, codel), metrics}}
       _ ->
-        {:noreply, {status, queue, start_poll(time, time, codel)}}
+        {:noreply, {status, queue, start_poll(time, time, codel), metrics}}
     end
   end
 
-  def handle_info({:timeout, idle, {time, last_sent}}, {_, _, %{idle: idle}} = data) do
+  def handle_info({:timeout, idle, {time, last_sent}}, {_, _, %{idle: idle}, _metrics} = data) do
     {status, queue, codel} = data
 
     # If no queue progress since last idle check oldest connection
@@ -128,18 +139,18 @@ defmodule DBConnection.ConnectionPool do
     end
   end
 
-  defp timeout(delay, time, queue, codel) do
+  defp timeout(delay, time, queue, codel, metrics) do
     case codel do
       %{delay: min_delay, next: next, target: target, interval: interval}
           when time >= next and min_delay > target ->
         codel = %{codel | slow: true, delay: delay, next: time + interval}
         drop_slow(time, target * 2, queue)
-        {:noreply, {:busy, queue, codel}}
+        {:noreply, {:busy, queue, codel, %{metrics | waiting_connections: metrics.waiting_connections - 1}}}
       %{next: next, interval: interval} when time >= next ->
         codel = %{codel | slow: false, delay: delay, next: time + interval}
-        {:noreply, {:busy, queue, codel}}
+        {:noreply, {:busy, queue, codel, metrics}}
       _ ->
-        {:noreply, {:busy, queue, codel}}
+        {:noreply, {:busy, queue, codel, metrics}}
     end
   end
 
@@ -159,27 +170,32 @@ defmodule DBConnection.ConnectionPool do
     {:noreply, {:ready, queue, codel}}
   end
 
-  defp handle_checkin(holder, now, {:ready, queue, _} = data) do
+  defp handle_checkin(holder, now, {:ready, queue, codel, metrics} = _data) do
     :ets.insert(queue, {{now, holder}})
-    {:noreply, data}
+    {:noreply, {:ready, queue, codel, %{metrics | active_connections: metrics.active_connections - 1}}}
   end
 
-  defp handle_checkin(holder, now, {:busy, queue, codel}) do
-    dequeue(now, holder, queue, codel)
+
+  defp handle_checkin(holder, now, {:busy, queue, codel, metrics}) do
+    # we're checking back in, but the queue is still busy, so we don't we've freed a connection
+    # so we can -1 active
+    dequeue(now, holder, queue, codel, metrics)
   end
 
-  defp dequeue(time, holder, queue, codel) do
+
+  defp dequeue(time, holder, queue, codel, metrics) do
+    # the we're selecting a thing off the queue, so add one to the waiting
     case codel do
       %{next: next, delay: delay, target: target} when time >= next  ->
-        dequeue_first(time, delay > target, holder, queue, codel)
+        dequeue_first(time, delay > target, holder, queue, codel, metrics)
       %{slow: false} ->
-        dequeue_fast(time, holder, queue, codel)
+        dequeue_fast(time, holder, queue, codel, metrics)
       %{slow: true, target: target} ->
-        dequeue_slow(time, target * 2, holder, queue, codel)
+        dequeue_slow(time, target * 2, holder, queue, codel, metrics)
     end
   end
 
-  defp dequeue_first(time, slow?, holder, queue, codel) do
+  defp dequeue_first(time, slow?, holder, queue, codel, metrics) do
     %{interval: interval} = codel
     next = time + interval
     case :ets.first(queue) do
@@ -187,48 +203,49 @@ defmodule DBConnection.ConnectionPool do
         :ets.delete(queue, key)
         delay = time - sent
         codel =  %{codel | next: next, delay: delay, slow: slow?}
-        go(delay, from, time, holder, queue, codel)
+        go(delay, from, time, holder, queue, codel, metrics)
       :"$end_of_table" ->
         codel = %{codel | next: next, delay: 0, slow: slow?}
         :ets.insert(queue, {{time, holder}})
-        {:noreply, {:ready, queue, codel}}
+        {:noreply, {:ready, queue, codel, %{metrics | waiting_connections: metrics.waiting_connections + 1}}}
     end
   end
 
-  defp dequeue_fast(time, holder, queue, codel) do
+  defp dequeue_fast(time, holder, queue, codel, metrics) do
     case :ets.first(queue) do
       {sent, _, from} = key ->
         :ets.delete(queue, key)
-        go(time - sent, from, time, holder, queue, codel)
+        go(time - sent, from, time, holder, queue, codel, metrics)
       :"$end_of_table" ->
         :ets.insert(queue, {{time, holder}})
-        {:noreply, {:ready, queue, %{codel | delay: 0}}}
+        {:noreply, {:ready, queue, %{codel | delay: 0}, %{metrics | waiting_connections: metrics.waiting_connections + 1}}}
     end
   end
 
-  defp dequeue_slow(time, timeout, holder, queue, codel) do
+  defp dequeue_slow(time, timeout, holder, queue, codel, metrics) do
     case :ets.first(queue) do
       {sent, _, from} = key when time - sent > timeout ->
         :ets.delete(queue, key)
         drop(time - sent, from)
-        dequeue_slow(time, timeout, holder, queue, codel)
+        dequeue_slow(time, timeout, holder, queue, codel, metrics)
       {sent, _, from} = key ->
         :ets.delete(queue, key)
-        go(time - sent, from, time, holder, queue, codel)
+        go(time - sent, from, time, holder, queue, codel, metrics)
       :"$end_of_table" ->
         :ets.insert(queue, {{time, holder}})
-        {:noreply, {:ready, queue, %{codel | delay: 0}}}
+        {:noreply, {:ready, queue, %{codel | delay: 0}, %{metrics | waiting_connections: metrics.waiting_connections + 1}}}
     end
   end
 
-  defp go(delay, from, time, holder, queue, %{delay: min} = codel) do
+  defp go(delay, from, time, holder, queue, %{delay: min} = codel, metrics) do
+    # when we successfully checked out a node, decrement the waiting and increment the active connections
     case Holder.handle_checkout(holder, from, queue) do
       true when delay < min ->
-        {:noreply, {:busy, queue, %{codel | delay: delay}}}
+        {:noreply, {:busy, queue, %{codel | delay: delay}, %{metrics | active_connections: metrics.active_connections + 1, waiting_connections: metrics.waiting_connections - 1}}}
       true ->
-        {:noreply, {:busy, queue, codel}}
+        {:noreply, {:busy, queue, %{codel | delay: delay}, %{metrics | active_connections: metrics.active_connections + 1, waiting_connections: metrics.waiting_connections - 1}}}
       false ->
-        dequeue(time, holder, queue, codel)
+        dequeue(time, holder, queue, codel, metrics)
     end
   end
 
@@ -237,7 +254,7 @@ defmodule DBConnection.ConnectionPool do
       "connection not available and request was dropped from queue after #{delay}ms. " <>
         "You can configure how long requests wait in the queue using :queue_target and " <>
         ":queue_interval. See DBConnection.start_link/2 for more information"
-
+    # drop one from waiting
     err = DBConnection.ConnectionError.exception(message)
     Holder.reply_error(from, err)
   end

--- a/mix.lock
+++ b/mix.lock
@@ -1,8 +1,8 @@
 %{
-  "connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [:mix], []},
-  "earmark": {:hex, :earmark, "1.3.2", "b840562ea3d67795ffbb5bd88940b1bed0ed9fa32834915125ea7d02e35888a5", [:mix], [], "hexpm"},
-  "ex_doc": {:hex, :ex_doc, "0.19.3", "3c7b0f02851f5fc13b040e8e925051452e41248f685e40250d7e40b07b9f8c10", [:mix], [{:earmark, "~> 1.2", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.10", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
-  "makeup": {:hex, :makeup, "0.8.0", "9cf32aea71c7fe0a4b2e9246c2c4978f9070257e5c9ce6d4a28ec450a839b55f", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
-  "makeup_elixir": {:hex, :makeup_elixir, "0.13.0", "be7a477997dcac2e48a9d695ec730b2d22418292675c75aa2d34ba0909dcdeda", [:mix], [{:makeup, "~> 0.8", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
-  "nimble_parsec": {:hex, :nimble_parsec, "0.5.0", "90e2eca3d0266e5c53f8fbe0079694740b9c91b6747f2b7e3c5d21966bba8300", [:mix], [], "hexpm"},
+  "connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [:mix], [], "hexpm", "4a0850c9be22a43af9920a71ab17c051f5f7d45c209e40269a1938832510e4d9"},
+  "earmark": {:hex, :earmark, "1.3.2", "b840562ea3d67795ffbb5bd88940b1bed0ed9fa32834915125ea7d02e35888a5", [:mix], [], "hexpm", "e3be2bc3ae67781db529b80aa7e7c49904a988596e2dbff897425b48b3581161"},
+  "ex_doc": {:hex, :ex_doc, "0.19.3", "3c7b0f02851f5fc13b040e8e925051452e41248f685e40250d7e40b07b9f8c10", [:mix], [{:earmark, "~> 1.2", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.10", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm", "0e11d67e662142fc3945b0ee410c73c8c956717fbeae4ad954b418747c734973"},
+  "makeup": {:hex, :makeup, "0.8.0", "9cf32aea71c7fe0a4b2e9246c2c4978f9070257e5c9ce6d4a28ec450a839b55f", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "5fbc8e549aa9afeea2847c0769e3970537ed302f93a23ac612602e805d9d1e7f"},
+  "makeup_elixir": {:hex, :makeup_elixir, "0.13.0", "be7a477997dcac2e48a9d695ec730b2d22418292675c75aa2d34ba0909dcdeda", [:mix], [{:makeup, "~> 0.8", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm", "adf0218695e22caeda2820eaba703fa46c91820d53813a2223413da3ef4ba515"},
+  "nimble_parsec": {:hex, :nimble_parsec, "0.5.0", "90e2eca3d0266e5c53f8fbe0079694740b9c91b6747f2b7e3c5d21966bba8300", [:mix], [], "hexpm", "5c040b8469c1ff1b10093d3186e2e10dbe483cd73d79ec017993fb3985b8a9b3"},
 }


### PR DESCRIPTION
This branch is based off of tag v2.0.6: https://github.com/elixir-ecto/db_connection/blob/v2.0.6/lib/db_connection/connection_pool.ex

This PR isn't meant to be merged. Currently, Triton is locked against Xandra 1.20 (https://github.com/blitzstudios/triton/blob/master/mix.exs#L30), which itself is locked against 2.0.6 of DBConnection (https://github.com/lexhide/xandra/blob/v0.12.0/mix.exs#L54).

So our requirements are:
Applications depend on Triton Master -> locked against Xandra 1.20 -> Xandra is locked against 2.0.6 of DBConnection -> this branch is forked from v2.0.6 of DBConnection.

This will definitely need to be branch deployed and upgraded in a fork of Xandra to support this. 